### PR TITLE
Add scoped PAT to fix sync-workflow permission issue

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ env.DEFAULT_BRANCH }}
+          token: ${{ secrets.SYNC_DOCS_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -36,5 +37,3 @@ jobs:
           git checkout ${{ env.DEFAULT_BRANCH }}
           git merge upstream/${{ env.DEFAULT_BRANCH }} --no-edit
           git push origin ${{ env.DEFAULT_BRANCH }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a scoped PAT which has permission to read/write to the **forked repo** and read/write to **workflows**.